### PR TITLE
Fix TSV output

### DIFF
--- a/scripts/count-up.py
+++ b/scripts/count-up.py
@@ -23,13 +23,13 @@ for x in sorted_samples:
 fp.write('\n')
 
 for gene in d_gene:
-    fp.write('%s\t' % gene)
+    output = []
+    output.append(gene)
     for x in sorted_samples:
         x1 = x.split('.')[0]
         if d_gene[gene].has_key(x1):
-            fp.write('%s\t' % d_gene[gene][x1])
+            output.append("%s" % d_gene[gene][x1])
         else:
-            fp.write('0\t')
-    fp.write('\n')
-
-
+            output.append('0')
+    fp.write("\t".join(output))
+    fp.write("\n")

--- a/scripts/import-ann.py
+++ b/scripts/import-ann.py
@@ -8,7 +8,7 @@ for record in screed.open(sys.argv[1]):
     d[id1] = id2
 
 for n, line in enumerate(open(sys.argv[2])):
-    dat = line.rstrip().split('\t')
+    dat = line.strip().split('\t')
     if n > 0:
         ann = d[dat[0]]
         dat.insert(1, ann)


### PR DESCRIPTION
Using `rstrip` leaves an empty space in the beginning of the line, which messes the header. I tried to import the generated TSV in pandas and it ends up with an extra column.

The fix is just to use `strip` instead of `rstrip`.
Pandas code:

``` python
import pandas as pd
data = pd.read_table("summary-count-annotated.tsv", sep="\t")
```
